### PR TITLE
Add overwrite option to resource copy operation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   byebug
@@ -55,4 +56,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   2.2.17
+   2.2.31

--- a/README.md
+++ b/README.md
@@ -70,11 +70,12 @@ Usage:
   sinopia-cli resource copy
 
 Options:
-  [--uri=one two three]  # Space separated list of source URIs.
-  [--file=FILE]          # File containing list of source URIs.
-  [--token=TOKEN]        # JWT token. Otherwise, read from .cognitoToken
+  [--uri=one two three]            # Space separated list of source URIs.
+  [--file=FILE]                    # File containing list of source URIs.
+  [--token=TOKEN]                  # JWT token. Otherwise, read from .cognitoToken
+  [--overwrite], [--no-overwrite]  # Overwrite resource if it already exists
   [--api-url=API_URL]
-                         # Default: https://api.stage.sinopia.io
+                                   # Default: https://api.stage.sinopia.io
 
 copy resources from one Sinopia environment to another
 ```

--- a/lib/client.rb
+++ b/lib/client.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'thor'
 require 'faraday'
 
 # Client for Sinopia API

--- a/lib/resource.rb
+++ b/lib/resource.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require 'thor'
 require 'client'
+require 'json'
+require 'thor'
 
 # Methods for resource endpoint
 class Resource < Thor

--- a/lib/sinopia_cli.rb
+++ b/lib/sinopia_cli.rb
@@ -2,7 +2,6 @@
 
 require 'thor'
 require 'resource'
-require 'json'
 
 # Base of the CLI
 class SinopiaCli < Thor


### PR DESCRIPTION
Connects to LD4P/rdf2marc#107

This commit adds the ability to specify an option when copying a resource that allows overwriting a resource if it exists.

Also includes:

* Update bundler lockfile with latest bundler version and linux platform
* Move require statements where needed (and only where needed)